### PR TITLE
Update class reference on AmpImg class

### DIFF
--- a/src/Concrete/Html/Object/AmpImg.php
+++ b/src/Concrete/Html/Object/AmpImg.php
@@ -1,7 +1,7 @@
 <?php
 namespace Concrete\Package\Amp\Html\Object;
 
-use Concrete\Core\File\File;
+use Concrete\Core\Entity\File\File;
 use HtmlObject\Traits\Tag;
 use Page;
 


### PR DESCRIPTION
This commit fixes the following issue-
```
Exception Occurred: /root_path/packages/amp/src/Concrete/Html/Object/AmpImg.php:26 Argument 1 passed to Concrete\Package\Amp\Html\Object\AmpImg::__construct() must be an instance of Concrete\Core\File\File, instance of Concrete\Core\Entity\File\File given
```